### PR TITLE
chore: pin hubot-help

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "hubot-diagnostics": "^1.2.1",
         "hubot-google-images": "^0.2.7",
         "hubot-google-translate": "^0.2.1",
-        "hubot-help": "^2.1.2",
+        "hubot-help": "2.1.2",
         "hubot-heroku-keepalive": "^1.0.3",
         "hubot-maps": "0.0.3",
         "hubot-pugme": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "hubot-diagnostics": "^1.2.1",
     "hubot-google-images": "^0.2.7",
     "hubot-google-translate": "^0.2.1",
-    "hubot-help": "^2.1.2",
+    "hubot-help": "2.1.2",
     "hubot-heroku-keepalive": "^1.0.3",
     "hubot-maps": "0.0.3",
     "hubot-pugme": "^0.1.1",


### PR DESCRIPTION
hubot-help 2.1.3 increases the required hubot version to 9 while we're still on 6.0.0